### PR TITLE
Minor script improvements

### DIFF
--- a/adb-uninstall
+++ b/adb-uninstall
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEVICECOUNT=$(echo "$(adb devices | wc -l) - 2" | bc)
+DEVICECOUNT=$(("$(adb devices | wc -l)" - 2))
 
-function prompt_yn(){
+function prompt_yn() {
     read -r -p "$1 [Y/n]" response
     [[ ${response,,} =~ ^(yes|y| ) || -z $response ]] && return 0 || return 1
 }
@@ -14,31 +14,30 @@ if [[ "$DEVICECOUNT" -eq 0 ]]; then
 fi
 
 if [[ "$DEVICECOUNT" -gt 1 ]]; then
-    SERIAL=$(adb devices -l | sed '1d' | head -n -1 \
-    | fzf --reverse --prompt "Select device: " --height=5 \
-    | cut -f 1 -d ' ' \
+    SERIAL=$(adb devices -l | sed '1d' | head -n -1 |
+        fzf --reverse --prompt "Select device: " --height=5 |
+        cut -f 1 -d ' '
     )
 else
     SERIAL=$(adb devices -l | sed '1d' | head -n -1 | cut -f 1 -d ' ')
 fi
 
-PACKAGES=$(adb -s "$SERIAL" shell pm list packages -3 | cut -d ':' -f 2 | sort \
-    | fzf --reverse --multi \
-    --preview-window right:40% \
-    --preview "echo {} | xargs -I % curl -s -o- \"https://play.google.com/store/apps/details?id=%\" |  grep -oh '<title id=\"main-title\">.*</title>'  | cut -d '>' -f 2 | cut -d '<' -f 1 | rev | cut -d '-' -f2- | rev" \
+mapfile -t PACKAGES < <(
+    adb -s "$SERIAL" shell pm list packages -3 | cut -d ':' -f 2 | sort |
+        fzf --reverse --multi \
+            --preview-window right:40% \
+            --preview "echo {} | xargs -I % curl -s -o- \"https://play.google.com/store/apps/details?id=%\" |  grep -oh '<title id=\"main-title\">.*</title>'  | cut -d '>' -f 2 | cut -d '<' -f 1 | rev | cut -d '-' -f2- | rev"
 )
 
-if [[ -n "$PACKAGES" ]]; then
-    PACKAGES_LIST=$(echo "$PACKAGES" | tr ' ' '\n')
-    echo "Selected packages ($(echo "${PACKAGES_LIST}" | wc -l)):"
-    echo "$PACKAGES"
+if [[ ${#PACKAGES[@]} -gt 0 ]]; then
+    echo "Selected packages (${#PACKAGES[@]}):"
+    printf '%s\n' "${PACKAGES[@]}"
     if prompt_yn "Confirm uninstall?"; then
-        for package in $PACKAGES_LIST
-        do
+        for package in "${PACKAGES[@]}"; do
             echo -n "$package - "
             if ! adb -s "$SERIAL" shell pm uninstall "$package"; then
                 if prompt_yn "Uninstallation failed. Try to uninstall as the android user?"; then
-                    adb -s "$SERIAL"  shell pm uninstall --user 0 "$package"
+                    adb -s "$SERIAL" shell pm uninstall --user 0 "$package"
                 fi
             fi
         done

--- a/adb-uninstall
+++ b/adb-uninstall
@@ -3,20 +3,9 @@ set -euo pipefail
 
 DEVICECOUNT=$(echo "$(adb devices | wc -l) - 2" | bc)
 
-
-function parse_response(){
-    local response
-    response=$(echo "$1" | tr '[:upper:]' '[:lower:]')
-    if [[ "$response" =~ ^(yes|y| ) ]] || [ -z "$response" ]; then
-        echo 0
-    else
-        echo 1
-    fi
-}
-
 function prompt_yn(){
     read -r -p "$1 [Y/n]" response
-    parse_response "$response"
+    [[ ${response,,} =~ ^(yes|y| ) || -z $response ]] && return 0 || return 1
 }
 
 if [[ "$DEVICECOUNT" -eq 0 ]]; then
@@ -43,12 +32,12 @@ if [[ -n "$PACKAGES" ]]; then
     PACKAGES_LIST=$(echo "$PACKAGES" | tr ' ' '\n')
     echo "Selected packages ($(echo "${PACKAGES_LIST}" | wc -l)):"
     echo "$PACKAGES"
-    if [[ $(prompt_yn "Confirm uninstall?") -eq 0 ]]; then
+    if prompt_yn "Confirm uninstall?"; then
         for package in $PACKAGES_LIST
         do
             echo -n "$package - "
             if ! adb -s "$SERIAL" shell pm uninstall "$package"; then
-                if [[ $(prompt_yn "Uninstallation failed. Try to uninstall as the android user?") -eq 0 ]]; then
+                if prompt_yn "Uninstallation failed. Try to uninstall as the android user?"; then
                     adb -s "$SERIAL"  shell pm uninstall --user 0 "$package"
                 fi
             fi

--- a/adb-uninstall
+++ b/adb-uninstall
@@ -16,7 +16,7 @@ function parse_response(){
 
 function prompt_yn(){
     read -r -p "$1 [Y/n]" response
-    echo $(parse_response "$response")
+    parse_response "$response"
 }
 
 if [[ "$DEVICECOUNT" -eq 0 ]]; then
@@ -39,7 +39,7 @@ PACKAGES=$(adb -s "$SERIAL" shell pm list packages -3 | cut -d ':' -f 2 | sort \
     --preview "echo {} | xargs -I % curl -s -o- \"https://play.google.com/store/apps/details?id=%\" |  grep -oh '<title id=\"main-title\">.*</title>'  | cut -d '>' -f 2 | cut -d '<' -f 1 | rev | cut -d '-' -f2- | rev" \
 )
 
-if [[ ! -z "$PACKAGES" ]]; then
+if [[ -n "$PACKAGES" ]]; then
     PACKAGES_LIST=$(echo "$PACKAGES" | tr ' ' '\n')
     echo "Selected packages ($(echo "${PACKAGES_LIST}" | wc -l)):"
     echo "$PACKAGES"


### PR DESCRIPTION
- Fix shellcheck warnings
- Improve prompt parsing
- Use bash array for PACKAGES & remove bc dependency

**Note:** that this introduces a reliance on some bash 4.0 features, however I don't think it will be too much of a problem since bash 4.0 was released in 2009